### PR TITLE
Implements Role based Configuration

### DIFF
--- a/ansible/roles/dbserver/tasks/main.yml
+++ b/ansible/roles/dbserver/tasks/main.yml
@@ -8,4 +8,4 @@
 - name:  Start services
   service: name={{ item }} state=started enabled=yes
   with_items:
-    - mysql-server
+    - mysqld

--- a/generate_inventory_file.sh
+++ b/generate_inventory_file.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# joshcb@amazon.com
+# Generates an Ansible Inventory file from an EC2 Tag
+# v1.0.0
+
+# Query metadata for our instance id and fetch values of the Roles tag
+tags=`ec2-describe-tags --filter "resource-type=instance" \
+  --filter "resource-id=$(ec2-metadata -i | cut -d ' ' -f2)" \
+  --filter "key=Roles" | cut -f5`
+# Whitespace get outta here we don't need you
+tags_no_whitespace="$(echo -e "${tags}" | tr -d '[[:space:]]')"
+
+# Wipe out existing file :fire:
+printf '' > /tmp/inventory
+
+# Sweet mother of... what is this witchcraft?!?!
+# I literally do not understand how this works
+# http://stackoverflow.com/questions/10586153/split-string-into-an-array-in-bash
+# http://timmurphy.org/2012/03/09/convert-a-delimited-string-into-an-array-in-bash/
+# This undoubtedly invokes some kind of unholy wrath :astonished:
+IFS=', ' read -r -a array <<< "$tags_no_whitespace"
+
+# Write out each role into an Ansible host group
+for element in "${array[@]}"
+do
+    printf "[$element]\nlocalhost ansible_connection=local\n" >> /tmp/inventory
+done

--- a/generate_inventory_file.sh
+++ b/generate_inventory_file.sh
@@ -4,9 +4,9 @@
 # v1.0.0
 
 # Query metadata for our instance id and fetch values of the Roles tag
-tags=`ec2-describe-tags --filter "resource-type=instance" \
-  --filter "resource-id=$(ec2-metadata -i | cut -d ' ' -f2)" \
-  --filter "key=Roles" | cut -f5`
+tags="$(ec2-describe-tags --filter \"resource-type=instance\" \
+  --filter \"resource-id=$(ec2-metadata -i | cut -d ' ' -f2)\" \
+  --filter \"key=Roles\" | cut -f5)"
 # Whitespace get outta here we don't need you
 tags_no_whitespace="$(echo -e "${tags}" | tr -d '[[:space:]]')"
 

--- a/generate_inventory_file.sh
+++ b/generate_inventory_file.sh
@@ -3,10 +3,14 @@
 # Generates an Ansible Inventory file from an EC2 Tag
 # v1.0.0
 
+# Set environment for ec2 tools
+source ~/.bash_profile
+
 # Query metadata for our instance id and fetch values of the Roles tag
 tags="$(/opt/aws/bin/ec2-describe-tags --filter \"resource-type=instance\" \
   --filter \"resource-id=$(/opt/aws/bin/ec2-metadata -i | cut -d ' ' -f2)\" \
   --filter \"key=Roles\" | cut -f5)"
+
 # Whitespace get outta here we don't need you
 tags_no_whitespace="$(echo -e "${tags}" | tr -d '[[:space:]]')"
 

--- a/generate_inventory_file.sh
+++ b/generate_inventory_file.sh
@@ -4,8 +4,8 @@
 # v1.0.0
 
 # Query metadata for our instance id and fetch values of the Roles tag
-tags="$(ec2-describe-tags --filter \"resource-type=instance\" \
-  --filter \"resource-id=$(ec2-metadata -i | cut -d ' ' -f2)\" \
+tags="$(/opt/aws/bin/ec2-describe-tags --filter \"resource-type=instance\" \
+  --filter \"resource-id=$(/opt/aws/bin/ec2-metadata -i | cut -d ' ' -f2)\" \
   --filter \"key=Roles\" | cut -f5)"
 # Whitespace get outta here we don't need you
 tags_no_whitespace="$(echo -e "${tags}" | tr -d '[[:space:]]')"

--- a/lambda/functions/trigger_run_command/main.py
+++ b/lambda/functions/trigger_run_command/main.py
@@ -102,6 +102,10 @@ def handle(event, context):
     try:
         job_id = event['CodePipeline.job']['id']
     except KeyError as err:
+        # TODO
+        # Better handle manual lambda invocations
+        # This will cause a ParamValidationError
+        job_id = 1
         LOGGER.error("Could not retrieve CodePipeline Job ID!\n%s", err)
 
     instance_ids = find_instances()

--- a/lambda/functions/trigger_run_command/main.py
+++ b/lambda/functions/trigger_run_command/main.py
@@ -3,7 +3,7 @@ Triggers Run Command on all instances with tag has_ssm_agent set to true,
 refreshes the git repository or clones it if it doesn't exist, and finally
 run Ansible locally on the instance to configure itself.
 joshcb@amazon.com
-v1.3.0
+v2.0.0
 """
 from __future__ import print_function
 import logging
@@ -16,6 +16,7 @@ LOGGER.setLevel(logging.INFO)
 COMMANDS = [
     'if cd /tmp/garlc; then git pull; else git clone ' \
     'https://github.com/irlrobot/garlc.git /tmp/garlc; fi',
+    'bash /tmp/garlc/generate_inventory_file.sh',
     'ansible-playbook -i "/tmp/inventory" /tmp/garlc/ansible/playbook.yml'
 ]
 

--- a/lambda/functions/trigger_run_command/main.py
+++ b/lambda/functions/trigger_run_command/main.py
@@ -69,7 +69,7 @@ def find_instances():
     try:
         for instance in instances['Reservations']:
             instance_ids.append(instance['Instances'][0]['InstanceId'])
-    except IndexError as err:
+    except KeyError as err:
         LOGGER.error("Unable to parse returned instances dict in " \
             "`find_instances` function!\n%s", err)
 
@@ -101,7 +101,7 @@ def handle(event, context):
     log_event_and_context(event, context)
     try:
         job_id = event['CodePipeline.job']['id']
-    except IndexError as err:
+    except KeyError as err:
         LOGGER.error("Could not retrieve CodePipeline Job ID!\n%s", err)
 
     instance_ids = find_instances()

--- a/lambda/functions/trigger_run_command/main.py
+++ b/lambda/functions/trigger_run_command/main.py
@@ -14,8 +14,8 @@ LOGGER = logging.getLogger()
 LOGGER.setLevel(logging.INFO)
 
 COMMANDS = [
-    'if cd /tmp/garlc; then git pull; else git clone ' \
-    'https://github.com/irlrobot/garlc.git /tmp/garlc; fi',
+    'if cd /tmp/garlc; then git fetch && git checkout master && git pull ; ',
+    'else git clone -b staging https://github.com/irlrobot/garlc.git /tmp/garlc; fi',
     'bash /tmp/garlc/generate_inventory_file.sh',
     'ansible-playbook -i "/tmp/inventory" /tmp/garlc/ansible/playbook.yml'
 ]

--- a/lambda/functions/trigger_run_command_staging/function.json
+++ b/lambda/functions/trigger_run_command_staging/function.json
@@ -1,0 +1,3 @@
+{
+  "description": "Invoke Run Command"
+}

--- a/lambda/functions/trigger_run_command_staging/main.py
+++ b/lambda/functions/trigger_run_command_staging/main.py
@@ -1,0 +1,117 @@
+"""
+Triggers Run Command on all instances with tag has_ssm_agent set to true,
+refreshes the git repository or clones it if it doesn't exist, and finally
+run Ansible locally on the instance to configure itself.
+joshcb@amazon.com
+v2.0.0
+"""
+from __future__ import print_function
+import logging
+import botocore
+import boto3
+
+LOGGER = logging.getLogger()
+LOGGER.setLevel(logging.INFO)
+
+COMMANDS = [
+    'if cd /tmp/garlc; then git pull; else git clone -b staging ' \
+    'https://github.com/irlrobot/garlc.git /tmp/garlc; fi',
+    'bash /tmp/garlc/generate_inventory_file.sh',
+    'ansible-playbook -i "/tmp/inventory" /tmp/garlc/ansible/playbook.yml'
+]
+
+def log_event_and_context(event, context):
+    """Logs event information for debugging"""
+    LOGGER.info("====================================================")
+    LOGGER.info(context)
+    LOGGER.info("====================================================")
+    LOGGER.info(event)
+    LOGGER.info("====================================================")
+
+def codepipeline_sucess(job_id):
+    """
+    Puts CodePipeline Success Result
+    """
+    try:
+        boto3.client('codepipeline').put_job_success_result(jobId=job_id)
+        LOGGER.info('===SUCCESS===')
+    except botocore.exceptions.ClientError as err:
+        LOGGER.error("Failed to PutJobSuccessResult for CodePipeline!\n%s", err)
+
+def codepipeline_failure(job_id, message):
+    """
+    Puts CodePipeline Failure Result
+    """
+    try:
+        boto3.client('codepipeline').put_job_failure_result(
+            jobId=job_id,
+            failureDetails={'type': 'JobFailed', 'message': message}
+        )
+        LOGGER.info('===FAILURE===')
+    except botocore.exceptions.ClientError as err:
+        LOGGER.error("Failed to PutJobFailureResult for CodePipeline!\n%s", err)
+
+def find_instances():
+    """
+    Find Instances to invoke Run Command against
+    """
+    instance_ids = []
+    filters = [{
+        'Name': 'tag:has_ssm_agent',
+        'Values': ['true', 'True']
+    }]
+    try:
+        ec2 = boto3.client('ec2')
+        instances = ec2.describe_instances(Filters=filters)
+    except botocore.exceptions.ClientError as err:
+        LOGGER.error("Failed to DescribeInstances with EC2!\n%s", err)
+
+    try:
+        for instance in instances['Reservations']:
+            instance_ids.append(instance['Instances'][0]['InstanceId'])
+    except IndexError as err:
+        LOGGER.error("Unable to parse returned instances dict in " \
+            "`find_instances` function!\n%s", err)
+
+    return instance_ids
+
+def send_run_command(instance_ids):
+    """
+    Sends the Run Command API Call
+    """
+    try:
+        ssm = boto3.client('ssm')
+        ssm.send_command(
+            InstanceIds=instance_ids,
+            DocumentName='AWS-RunShellScript',
+            TimeoutSeconds=60,
+            Parameters={
+                'commands': COMMANDS,
+                'executionTimeout': ['120']
+            }
+        )
+        return 'success'
+    except botocore.exceptions.ClientError as err:
+        return err
+
+def handle(event, context):
+    """
+    Lambda main handler
+    """
+    log_event_and_context(event, context)
+    try:
+        job_id = event['CodePipeline.job']['id']
+    except IndexError as err:
+        LOGGER.error("Could not retrieve CodePipeline Job ID!\n%s", err)
+
+    instance_ids = find_instances()
+
+    if len(instance_ids) != 0:
+        run_command_status = send_run_command(instance_ids)
+        if run_command_status == 'success':
+            codepipeline_sucess(job_id)
+        else:
+            codepipeline_failure(job_id, ("Run Command Failed!\n%s",
+                                          run_command_status))
+    else:
+        codepipeline_failure(job_id, 'No Instance IDs Provided!')

--- a/lambda/functions/trigger_run_command_staging/main.py
+++ b/lambda/functions/trigger_run_command_staging/main.py
@@ -102,6 +102,7 @@ def handle(event, context):
     try:
         job_id = event['CodePipeline.job']['id']
     except IndexError as err:
+        job_id = 1
         LOGGER.error("Could not retrieve CodePipeline Job ID!\n%s", err)
 
     instance_ids = find_instances()

--- a/lambda/functions/trigger_run_command_staging/main.py
+++ b/lambda/functions/trigger_run_command_staging/main.py
@@ -3,7 +3,7 @@ Triggers Run Command on all instances with tag has_ssm_agent set to true,
 refreshes the git repository or clones it if it doesn't exist, and finally
 run Ansible locally on the instance to configure itself.
 joshcb@amazon.com
-v2.0.0
+v2.0.1
 """
 from __future__ import print_function
 import logging
@@ -14,7 +14,7 @@ LOGGER = logging.getLogger()
 LOGGER.setLevel(logging.INFO)
 
 COMMANDS = [
-    'if cd /tmp/garlc; then git pull; else git clone -b staging ' \
+    'if cd /tmp/garlc; then git fetch && git checkout staging && git pull ; else git clone -b staging ' \
     'https://github.com/irlrobot/garlc.git /tmp/garlc; fi',
     'bash /tmp/garlc/generate_inventory_file.sh',
     'ansible-playbook -i "/tmp/inventory" /tmp/garlc/ansible/playbook.yml'

--- a/lambda/functions/trigger_run_command_staging/main.py
+++ b/lambda/functions/trigger_run_command_staging/main.py
@@ -102,6 +102,9 @@ def handle(event, context):
     try:
         job_id = event['CodePipeline.job']['id']
     except KeyError as err:
+        # TODO
+        # Better handle manual lambda invocations
+        # This will cause a ParamValidationError
         job_id = 1
         LOGGER.error("Could not retrieve CodePipeline Job ID!\n%s", err)
 

--- a/lambda/functions/trigger_run_command_staging/main.py
+++ b/lambda/functions/trigger_run_command_staging/main.py
@@ -14,8 +14,8 @@ LOGGER = logging.getLogger()
 LOGGER.setLevel(logging.INFO)
 
 COMMANDS = [
-    'if cd /tmp/garlc; then git fetch && git checkout staging && git pull ; else git clone -b staging ' \
-    'https://github.com/irlrobot/garlc.git /tmp/garlc; fi',
+    'if cd /tmp/garlc; then git fetch && git checkout staging && git pull ; ',
+    'else git clone -b staging https://github.com/irlrobot/garlc.git /tmp/garlc; fi',
     'bash /tmp/garlc/generate_inventory_file.sh',
     'ansible-playbook -i "/tmp/inventory" /tmp/garlc/ansible/playbook.yml'
 ]

--- a/lambda/functions/trigger_run_command_staging/main.py
+++ b/lambda/functions/trigger_run_command_staging/main.py
@@ -69,7 +69,7 @@ def find_instances():
     try:
         for instance in instances['Reservations']:
             instance_ids.append(instance['Instances'][0]['InstanceId'])
-    except IndexError as err:
+    except KeyError as err:
         LOGGER.error("Unable to parse returned instances dict in " \
             "`find_instances` function!\n%s", err)
 
@@ -101,7 +101,7 @@ def handle(event, context):
     log_event_and_context(event, context)
     try:
         job_id = event['CodePipeline.job']['id']
-    except IndexError as err:
+    except KeyError as err:
         job_id = 1
         LOGGER.error("Could not retrieve CodePipeline Job ID!\n%s", err)
 


### PR DESCRIPTION
Define the Ansible roles you want to run by adding a "Roles" tag with a comma separated list of role names.  Run Command will kick off a script to parse tags and write an Inventory file which Ansible uses to run associated plays.

Several things to note here:
- Roles tag is case sensitive
- Relies on having ec2 tools on the instance
- Instance role must have Describe* permissions